### PR TITLE
Improved String Parsing and Handling for Declared Units

### DIFF
--- a/CarbonQueryDatabase_Adapter/CRUD/Read.cs
+++ b/CarbonQueryDatabase_Adapter/CRUD/Read.cs
@@ -30,6 +30,7 @@ using BH.oM.Adapter;
 using BH.oM.Adapter.CarbonQueryDatabase;
 using BH.oM.HTTP;
 using BH.Engine.HTTP;
+using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.Engine.CarbonQueryDatabase;
 using BH.oM.LifeCycleAssessment;
 using BH.Adapter;

--- a/CarbonQueryDatabase_Adapter/CRUD/Read.cs
+++ b/CarbonQueryDatabase_Adapter/CRUD/Read.cs
@@ -30,7 +30,6 @@ using BH.oM.Adapter;
 using BH.oM.Adapter.CarbonQueryDatabase;
 using BH.oM.HTTP;
 using BH.Engine.HTTP;
-using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.Engine.CarbonQueryDatabase;
 using BH.oM.LifeCycleAssessment;
 using BH.Adapter;

--- a/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
+++ b/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
@@ -32,7 +32,6 @@ using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Base;
 using BH.oM.LifeCycleAssessment;
-using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.Engine.Reflection;
 using System.Collections;
 using BH.Engine.CarbonQueryDatabase;

--- a/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
+++ b/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
@@ -32,6 +32,7 @@ using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Base;
 using BH.oM.LifeCycleAssessment;
+using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.Engine.Reflection;
 using System.Collections;
 using BH.Engine.CarbonQueryDatabase;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #37 

Decks and other similar EPD's with declared units not equal to 1 are now factored appropriately. Declared unit strings with unique conditions such as no space between value and units are now parsed properly as well using RegEx.


### Test files
Any pull script bringing in decks (NameLike = "Deck" works).
