### PR TITLE
Fix unit convert handling for US and Metric Tons

### DIFF
--- a/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
+++ b/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
@@ -202,12 +202,15 @@ namespace BH.Adapter.CarbonQueryDatabase
                     return val.ToCubicYard();
                 case "t":
                 case "short ton":
-                    unitMult = 0.000984207;
+                    unitMult = 0.00110231;
                     break;
                 case "tonne":
                 case "metric ton":
                     unitMult = 0.001;
                     break;
+                case "lb":
+                case "pound":
+                    return val.ToPoundForce();
                 case "sq ft":
                 case "sqft":
                 case "ft2":

--- a/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
+++ b/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
@@ -200,11 +200,11 @@ namespace BH.Adapter.CarbonQueryDatabase
                 case "yd³":
                 case "y³":
                     return val.ToCubicYard();
-                case "t":
                 case "short ton":
                     unitMult = 0.00110231;
                     break;
                 case "tonne":
+                case "t":
                 case "metric ton":
                     unitMult = 0.001;
                     break;


### PR DESCRIPTION
### Issues addressed by this PR
Closes #41 


Fixes unit conversion issues for short tons and unit conventions per EC3.


### Test files
Test any existing pull scripts with "Fabricated Hot-Rolled Structural Steel Sections" (which uses 1 t as its declared unit) and confirm it matches to EC3 once accounting for SI unit conversions for lbs>kgs.

