### PR TITLE
Fix for declared unit translation when it is a string only without leading "1"

### DIFF
--- a/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
+++ b/CarbonQueryDatabase_Adapter/Convert/ToBHoM.cs
@@ -240,6 +240,8 @@ namespace BH.Adapter.CarbonQueryDatabase
             string numString = str.Substring(0, match.Index);
             double val = double.NaN;
             Double.TryParse(numString, out val);
+            if (numString == "")
+                { val = 1; }
             return val;
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #50 

Added catch for when declared unit is expressed as a string only, eg "yd3", so that it is understood as being equal to 1 yd3.


### Test files
Any CQD pull using EPDs with declared unit yd3. ID suggested is "ec334mqm".