### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/CarbonQueryDatabase_Adapter/CarbonQueryDatabase_Adapter.csproj
+++ b/CarbonQueryDatabase_Adapter/CarbonQueryDatabase_Adapter.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.CarbonQueryDatabase</RootNamespace>
     <AssemblyName>CarbonQueryDatabase_Adapter</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/CarbonQueryDatabase_Engine/CarbonQueryDatabase_Engine.csproj
+++ b/CarbonQueryDatabase_Engine/CarbonQueryDatabase_Engine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.Adapters.CarbonQueryDatabase</RootNamespace>
     <AssemblyName>CarbonQueryDatabase_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/CarbonQueryDatabase_oM/CarbonQueryDatabase_oM.csproj
+++ b/CarbonQueryDatabase_oM/CarbonQueryDatabase_oM.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.oM.Adapters.CarbonQueryDatabase</RootNamespace>
     <AssemblyName>CarbonQueryDatabase_oM</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it.